### PR TITLE
add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+on: [push, pull_request]
+
+name: Code Coverage
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: --all-features --tests --doc
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2.1.0
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://travis-ci.org/mehcode/config-rs.svg?branch=master)](https://travis-ci.org/mehcode/config-rs)
 [![Crates.io](https://img.shields.io/crates/d/config.svg)](https://crates.io/crates/config)
 [![Docs.rs](https://docs.rs/config/badge.svg)](https://docs.rs/config)
+[![codecov](https://codecov.io/gh/mehcode/config-rs/branch/master/graph/badge.svg)](https://codecov.io/gh/mehcode/config-rs)
 
 > Layered configuration system for Rust applications (with strong support for [12-factor] applications).
 


### PR DESCRIPTION
adds a coverage workflow using `tarpauling` and `codecov.io`

this will require setting up a codecov account to work (using github 0auth2)