### PR TITLE
fix: Change YAML crate to `serde_yaml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [features]
 default = ["toml", "json", "yaml", "ini", "ron", "json5", "convert-case", "async"]
 json = ["serde_json"]
-yaml = ["yaml-rust"]
+yaml = ["serde_yaml"]
 ini = ["rust-ini"]
 json5 = ["json5_rs", "serde/derive"]
 convert-case = ["convert_case"]
@@ -32,7 +32,7 @@ nom = "7"
 async-trait = { version = "0.1.50", optional = true }
 toml = { version = "0.8", optional = true }
 serde_json = { version = "1.0.2", optional = true }
-yaml-rust = { version = "0.4", optional = true }
+serde_yaml  = { version = "0.9", optional = true }
 rust-ini = { version = "0.19", optional = true }
 ron = { version = "0.8", optional = true }
 json5_rs = { version = "0.4", optional = true, package = "json5" }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 [JSON]: https://github.com/serde-rs/json
 [TOML]: https://github.com/toml-lang/toml
-[YAML]: https://github.com/chyh1990/yaml-rust
+[YAML]: https://github.com/dtolnay/serde-yaml
 [INI]: https://github.com/zonyitoo/rust-ini
 [RON]: https://github.com/ron-rs/ron
 [JSON5]: https://github.com/callum-oakley/json5-rs

--- a/src/file/format/mod.rs
+++ b/src/file/format/mod.rs
@@ -40,7 +40,7 @@ pub enum FileFormat {
     #[cfg(feature = "json")]
     Json,
 
-    /// YAML (parsed with yaml_rust)
+    /// YAML (parsed with serde_yaml)
     #[cfg(feature = "yaml")]
     Yaml,
 

--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -1,8 +1,4 @@
 use std::error::Error;
-use std::fmt;
-use std::mem;
-
-use yaml_rust as yaml;
 
 use crate::format;
 use crate::map::Map;
@@ -12,94 +8,53 @@ pub fn parse(
     uri: Option<&String>,
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
-    // Parse a YAML object from file
-    let mut docs = yaml::YamlLoader::load_from_str(text)?;
-    let root = match docs.len() {
-        0 => yaml::Yaml::Hash(yaml::yaml::Hash::new()),
-        1 => mem::replace(&mut docs[0], yaml::Yaml::Null),
-        n => {
-            return Err(Box::new(MultipleDocumentsError(n)));
-        }
-    };
-
-    let value = from_yaml_value(uri, &root)?;
+    // Parse a YAML input from the provided text
+    let value = from_yaml_value(uri, serde_yaml::from_str(text)?);
     format::extract_root_table(uri, value)
 }
 
-fn from_yaml_value(
-    uri: Option<&String>,
-    value: &yaml::Yaml,
-) -> Result<Value, Box<dyn Error + Send + Sync>> {
-    match *value {
-        yaml::Yaml::String(ref value) => Ok(Value::new(uri, ValueKind::String(value.clone()))),
-        yaml::Yaml::Real(ref value) => {
-            // TODO: Figure out in what cases this can panic?
-            value
-                .parse::<f64>()
-                .map_err(|_| {
-                    Box::new(FloatParsingError(value.to_string())) as Box<(dyn Error + Send + Sync)>
+pub fn from_yaml_value(uri: Option<&String>, value: serde_yaml::Value) -> Value {
+    let vk = match value {
+        serde_yaml::Value::Tagged(_) | serde_yaml::Value::Null => ValueKind::Nil,
+        serde_yaml::Value::Bool(v) => ValueKind::Boolean(v),
+        serde_yaml::Value::String(v) => ValueKind::String(v),
+
+        serde_yaml::Value::Number(v) => {
+            if v.is_i64() {
+                ValueKind::I64(v.as_i64().expect("i64"))
+            } else if v.is_u64() {
+                ValueKind::U64(v.as_u64().expect("u64"))
+            } else if v.is_f64() {
+                ValueKind::Float(v.as_f64().expect("f64"))
+            } else {
+                ValueKind::Nil
+            }
+        }
+
+        serde_yaml::Value::Mapping(table) => {
+            let m = table
+                .into_iter()
+                .map(|(k, v)| {
+                    let key = match k {
+                        serde_yaml::Value::Number(v) => v.to_string(),
+                        serde_yaml::Value::String(v) => v,
+
+                        _ => unreachable!(),
+                    };
+                    let value = from_yaml_value(uri, v);
+                    (key, value)
                 })
-                .map(ValueKind::Float)
-                .map(|f| Value::new(uri, f))
-        }
-        yaml::Yaml::Integer(value) => Ok(Value::new(uri, ValueKind::I64(value))),
-        yaml::Yaml::Boolean(value) => Ok(Value::new(uri, ValueKind::Boolean(value))),
-        yaml::Yaml::Hash(ref table) => {
-            let mut m = Map::new();
-            for (key, value) in table {
-                match key {
-                    yaml::Yaml::String(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
-                    yaml::Yaml::Integer(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
-                    _ => unreachable!(),
-                };
-            }
-            Ok(Value::new(uri, ValueKind::Table(m)))
-        }
-        yaml::Yaml::Array(ref array) => {
-            let mut l = Vec::new();
+                .collect();
 
-            for value in array {
-                l.push(from_yaml_value(uri, value)?);
-            }
-
-            Ok(Value::new(uri, ValueKind::Array(l)))
+            ValueKind::Table(m)
         }
 
-        // 1. Yaml NULL
-        // 2. BadValue – It shouldn't be possible to hit BadValue as this only happens when
-        //               using the index trait badly or on a type error but we send back nil.
-        // 3. Alias – No idea what to do with this and there is a note in the lib that its
-        //            not fully supported yet anyway
-        _ => Ok(Value::new(uri, ValueKind::Nil)),
-    }
-}
+        serde_yaml::Value::Sequence(array) => {
+            let l = array.into_iter().map(|v| from_yaml_value(uri, v)).collect();
 
-#[derive(Debug, Copy, Clone)]
-struct MultipleDocumentsError(usize);
+            ValueKind::Array(l)
+        }
+    };
 
-impl fmt::Display for MultipleDocumentsError {
-    fn fmt(&self, format: &mut fmt::Formatter) -> fmt::Result {
-        write!(format, "Got {} YAML documents, expected 1", self.0)
-    }
-}
-
-impl Error for MultipleDocumentsError {
-    fn description(&self) -> &str {
-        "More than one YAML document provided"
-    }
-}
-
-#[derive(Debug, Clone)]
-struct FloatParsingError(String);
-
-impl fmt::Display for FloatParsingError {
-    fn fmt(&self, format: &mut fmt::Formatter) -> fmt::Result {
-        write!(format, "Parsing {} as floating point number failed", self.0)
-    }
-}
-
-impl Error for FloatParsingError {
-    fn description(&self) -> &str {
-        "Floating point number parsing failed"
-    }
+    Value::new(uri, vk)
 }

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -81,12 +81,13 @@ fn test_error_parse() {
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
 
+    // Should fail to parse block mapping as no `:` exists to identify a key
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            "while parsing a block mapping, did not find expected key at \
-         line 2 column 1 in {}",
+            "could not find expected ':' at line 3 column 1, \
+            while scanning a simple key at line 2 column 1 in {}",
             path_with_extension.display()
         )
     );

--- a/tests/legacy/file_yaml.rs
+++ b/tests/legacy/file_yaml.rs
@@ -81,12 +81,13 @@ fn test_error_parse() {
 
     let path_with_extension: PathBuf = ["tests", "Settings-invalid.yaml"].iter().collect();
 
+    // Should fail to parse block mapping as no `:` exists to identify a key
     assert!(res.is_err());
     assert_eq!(
         res.unwrap_err().to_string(),
         format!(
-            "while parsing a block mapping, did not find expected key at \
-         line 2 column 1 in {}",
+            "could not find expected ':' at line 3 column 1, \
+            while scanning a simple key at line 2 column 1 in {}",
             path_with_extension.display()
         )
     );


### PR DESCRIPTION
- `yaml-rust` is unmaintained for over 2 years.
- Like with `yaml-rust`, requires special handling for table keys (_ensuring numbers are converted to strings_).

Resolves: https://github.com/mehcode/config-rs/issues/473

---

Just some insights below that might be worth noting considering the switch. Presumably this should be delayed until a breaking release is acceptable?

Since `config-rs` is only interested in deserialization, some [concerns users may have regarding serializing valid YAML files](https://github.com/dtolnay/serde-yaml/issues/380) may be a non-issue, but changing from one YAML crate to another may behave differently with deserialization still:
- Prior to the [`0.9` release](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0) (July 2022) of `serde_yaml`, it used the `yaml-rust` crate internally. Now it uses a [transpiled `libyaml` crate](https://github.com/dtolnay/unsafe-libyaml).
- The `yaml-rust` format had parsing logic by `config-rs` to ensure a single document or create an empty Map. You should get [similar with `serde_yaml`](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.20) for an empty Map or `ValueKind::Nil`
- [Numbers can be keys](https://github.com/stoplightio/yaml/issues/34), but have always been converted to strings for the `Map` type in `config-rs`.
  - There is an existing [test-case YAML config for this](https://github.com/mehcode/config-rs/blob/55c464e143d7301f3c107a405827fe9dc085f81a/tests/test-keys.yaml) with mixed number and string keys. No difference in behaviour here than what we already had.
  - There is a [tracking issue at `serde_yaml`](https://github.com/dtolnay/serde-yaml/issues/165#issuecomment-644311452), ideally that would be resolved upstream to properly handle number to string conversion (_only seems to be an issue for untagged enums_).
- `serde_yaml` changed tagged enums with [`0.9` release](https://github.com/dtolnay/serde-yaml/releases/tag/0.9.0), that is [causing some issues from users upgrading from `0.8`](https://github.com/dtolnay/serde-yaml/issues/361). `config-rs` test suite is passing, but the test coverage for config files input to Rust types may not cover some of these concerns? 🤷‍♂️ 
- Some YAML parsers have a wider range of values that are treated as booleans based on YAML 1.1 spec apparently, while [`serde_yaml` only implements support for what the YAML 1.2 spec states should be treated as bools](https://github.com/dtolnay/serde-yaml/pull/330).
  - A [request for wider support was rejected](https://github.com/dtolnay/serde-yaml/issues/379#issuecomment-1621990180).
  - It [may be encountered in some configs like Ansible](https://github.com/dtolnay/serde-yaml/issues/384), where it's considered a valid bool value type. I've not checked if `yaml-rust` is any better at this though.
- What may look like [an invalid config, may be treated as a single `String`](https://github.com/dtolnay/serde-yaml/issues/372) instead of throwing an error depending on the input, as it's technically valid.