### PR TITLE
Programmatically advertize MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["Ryan Leckey <leckey.ryan@gmail.com>"]
 categories = ["config"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.75"
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
This makes it easier for people to see the MSRV on crates.io and will be important as MSRV-aware resolver is developed.