### PR TITLE
Environment Variable List of Structs

### DIFF
--- a/examples/env-list/main.rs
+++ b/examples/env-list/main.rs
@@ -1,18 +1,31 @@
 use config::Config;
+
+#[derive(Debug, Default, serde_derive::Deserialize, PartialEq, Eq)]
+struct ListOfStructs {
+    a: String,
+    b: String,
+}
+
 #[derive(Debug, Default, serde_derive::Deserialize, PartialEq, Eq)]
 struct AppConfig {
     list: Vec<String>,
+    structs: Vec<Option<ListOfStructs>>,
 }
 
 fn main() {
     std::env::set_var("APP_LIST", "Hello World");
+    std::env::set_var("APP_STRUCTS_0_A", "Hello");
+    std::env::set_var("APP_STRUCTS_0_B", "World");
+    std::env::set_var("APP_STRUCTS_2_A", "foo");
+    std::env::set_var("APP_STRUCTS_2_B", "bar");
 
     let config = Config::builder()
         .add_source(
             config::Environment::with_prefix("APP")
                 .try_parsing(true)
                 .separator("_")
-                .list_separator(" "),
+                .list_separator(" ")
+                .with_list_parse_key("list"),
         )
         .build()
         .unwrap();
@@ -20,6 +33,20 @@ fn main() {
     let app: AppConfig = config.try_deserialize().unwrap();
 
     assert_eq!(app.list, vec![String::from("Hello"), String::from("World")]);
+    assert_eq!(
+        app.structs,
+        vec![
+            Some(ListOfStructs {
+                a: String::from("Hello"),
+                b: String::from("World")
+            }),
+            None,
+            Some(ListOfStructs {
+                a: String::from("foo"),
+                b: String::from("bar")
+            }),
+        ]
+    );
 
     std::env::remove_var("APP_LIST");
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -13,6 +13,63 @@ use convert_case::{Case, Casing};
 /// config Value type. We have to be aware how the config tree is created from the environment
 /// dictionary, therefore we are mindful about prefixes for the environment keys, level separators,
 /// encoding form (kebab, snake case) etc.
+///
+/// Environment variables are specified using the path to the key they correspond to. When
+/// specifying a value within a list, the index should be specified in the key immediately after
+/// the list type.
+///
+/// ## Example
+///
+/// ```rust
+/// # use config::{Environment, Config};
+/// # use serde::Deserialize;
+/// # use std::collections::HashMap;
+/// # use std::convert::TryInto;
+/// #
+/// # #[test]
+/// # fn test_env_list_of_structs() {
+///     #[derive(Deserialize, Debug, PartialEq)]
+///     struct Struct {
+///         a: Vec<Option<u32>>,
+///         b: u32,
+///     }
+///
+///     #[derive(Deserialize, Debug)]
+///     struct ListOfStructs {
+///         list: Vec<Struct>,
+///     }
+///
+///     let values = vec![
+///         ("LIST_0_A_0".to_owned(), "1".to_owned()),
+///         ("LIST_0_A_2".to_owned(), "2".to_owned()),
+///         ("LIST_0_B".to_owned(), "3".to_owned()),
+///         ("LIST_1_A_1".to_owned(), "4".to_owned()),
+///         ("LIST_1_B".to_owned(), "5".to_owned()),
+///     ];
+///
+///     let environment = Environment::default()
+///         .separator("_")
+///         .try_parsing(true)
+///         .source(Some(values.into_iter().collect()));
+///
+///     let config = Config::builder().add_source(environment).build().unwrap();
+///
+///     let config: ListOfStructs = config.try_deserialize().unwrap();
+///     assert_eq!(
+///         config.list,
+///         vec![
+///             Struct {
+///                 a: vec![Some(1), None, Some(2)],
+///                 b: 3
+///             },
+///             Struct {
+///                 a: vec![None, Some(4)],
+///                 b: 5
+///             },
+///         ]
+///     );
+/// # }
+/// ```
 #[must_use]
 #[derive(Clone, Debug, Default)]
 pub struct Environment {
@@ -291,11 +348,10 @@ impl Source for Environment {
                 } else if let Ok(parsed) = value.parse::<f64>() {
                     ValueKind::Float(parsed)
                 } else if let Some(separator) = &self.list_separator {
-                    if let Some(keys) = &self.list_parse_keys {
+                    if let Some(parse_keys) = &self.list_parse_keys {
                         #[cfg(feature = "convert-case")]
                         let key = key.to_lowercase();
-
-                        if keys.contains(&key) {
+                        if parse_keys.contains(&key) {
                             let v: Vec<Value> = value
                                 .split(separator)
                                 .map(|s| Value::new(Some(&uri), ValueKind::String(s.to_owned())))

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -48,7 +48,7 @@ fn test_separator_behavior() {
     temp_env::with_var("C_B_A", Some("abc"), || {
         let environment = Environment::with_prefix("C").separator("_");
 
-        assert!(environment.collect().unwrap().contains_key("b.a"));
+        assert!(environment.collect().unwrap().contains_key("b"));
     });
 }
 
@@ -85,7 +85,7 @@ fn test_custom_separator_behavior() {
     temp_env::with_var("C.B.A", Some("abc"), || {
         let environment = Environment::with_prefix("C").separator(".");
 
-        assert!(environment.collect().unwrap().contains_key("b.a"));
+        assert!(environment.collect().unwrap().contains_key("b"));
     });
 }
 
@@ -96,7 +96,7 @@ fn test_custom_prefix_separator_behavior() {
             .separator(".")
             .prefix_separator("-");
 
-        assert!(environment.collect().unwrap().contains_key("b.a"));
+        assert!(environment.collect().unwrap().contains_key("b"));
     });
 }
 
@@ -723,4 +723,48 @@ fn test_parse_uint_default() {
 
     let config: TestUint = config.try_deserialize().unwrap();
     assert_eq!(config.int_val, 42);
+}
+
+#[test]
+fn test_env_list_of_structs() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Struct {
+        a: Vec<Option<u32>>,
+        b: u32,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct ListOfStructs {
+        list: Vec<Struct>,
+    }
+
+    let values = vec![
+        ("LIST_0_A_0".to_owned(), "1".to_owned()),
+        ("LIST_0_A_2".to_owned(), "2".to_owned()),
+        ("LIST_0_B".to_owned(), "3".to_owned()),
+        ("LIST_1_A_1".to_owned(), "4".to_owned()),
+        ("LIST_1_B".to_owned(), "5".to_owned()),
+    ];
+
+    let environment = Environment::default()
+        .separator("_")
+        .try_parsing(true)
+        .source(Some(values.into_iter().collect()));
+
+    let config = Config::builder().add_source(environment).build().unwrap();
+
+    let config: ListOfStructs = config.try_deserialize().unwrap();
+    assert_eq!(
+        config.list,
+        vec![
+            Struct {
+                a: vec![Some(1), None, Some(2)],
+                b: 3
+            },
+            Struct {
+                a: vec![None, Some(4)],
+                b: 5
+            },
+        ]
+    );
 }


### PR DESCRIPTION
Enables specifying lists of structs within environment variables.

### Example

```rust
    #[derive(Deserialize, Debug, PartialEq)]
    struct Struct {
        a: Vec<Option<u32>>,
        b: u32,
    }

    #[derive(Deserialize, Debug)]
    struct ListOfStructs {
        list: Vec<Struct>,
    }

    let values = vec![
        ("LIST_0_A_0".to_owned(), "1".to_owned()),
        ("LIST_0_A_2".to_owned(), "2".to_owned()),
        ("LIST_0_B".to_owned(), "3".to_owned()),
        ("LIST_1_A_1".to_owned(), "4".to_owned()),
        ("LIST_1_B".to_owned(), "5".to_owned()),
    ];

    let environment = Environment::default()
        .separator("_")
        .try_parsing(true)
        .source(Some(values.into_iter().collect()));

    let config = Config::builder().add_source(environment).build().unwrap();

    let config: ListOfStructs = config.try_deserialize().unwrap();
    assert_eq!(
        config.list,
        vec![
            Struct {
                a: vec![Some(1), None, Some(2)],
                b: 3
            },
            Struct {
                a: vec![None, Some(4)],
                b: 5
            },
        ]
    );
```