### PR TITLE
fix: convert the keys in the array to lowercase

### DIFF
--- a/tests/Settings.yaml
+++ b/tests/Settings.yaml
@@ -12,6 +12,9 @@ place:
     name: John Smith
     username: jsmith
     email: jsmith@localhost
+Student:
+  - Name: Tom
+  - Name: Bob
 # For override tests
 FOO: FOO should be overridden
 bar: I am bar

--- a/tests/file_yaml.rs
+++ b/tests/file_yaml.rs
@@ -183,6 +183,8 @@ fn test_override_lowercase_value_for_struct() {
         .build()
         .unwrap();
 
+    assert_eq!(cfg.get_string("Student[0].Name").unwrap(), "Tom".to_owned());
+
     let values: StructSettings = cfg.try_deserialize().unwrap();
     assert_eq!(
         values.bar,


### PR DESCRIPTION
fix https://github.com/rust-cli/config-rs/issues/609

[turn keys to lowercase to enable cross overrides](https://github.com/rust-cli/config-rs/commit/d2ee90ea23281b057dffa6515b274e5c7b82cf87) not convert the keys in the array to lowercase. This PR fix it. 

Before fix:
![image](https://github.com/user-attachments/assets/e5182384-e44a-48c8-aa62-ee96ed432724)

After fix:
![image](https://github.com/user-attachments/assets/31cfebae-8dad-40dd-8a42-e2438deb89c0)
