### PR TITLE
Improve path parse error messages

### DIFF
--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -27,7 +27,7 @@ impl FromStr for Expression {
 struct ParseError(String);
 
 impl ParseError {
-    fn new(inner: winnow::error::ContextError) -> Self {
+    fn new(inner: winnow::error::ParseError<&str, winnow::error::ContextError>) -> Self {
         Self(inner.to_string())
     }
 }

--- a/src/path/parser.rs
+++ b/src/path/parser.rs
@@ -117,4 +117,34 @@ mod test {
 
         assert_eq!(parsed, expected);
     }
+
+    #[test]
+    fn test_invalid_identifier() {
+        let err = from_str("!").unwrap_err();
+        assert_eq!("", err.to_string());
+    }
+
+    #[test]
+    fn test_invalid_child() {
+        let err = from_str("a..").unwrap_err();
+        assert_eq!("", err.to_string());
+    }
+
+    #[test]
+    fn test_invalid_subscript() {
+        let err = from_str("a[b]").unwrap_err();
+        assert_eq!("", err.to_string());
+    }
+
+    #[test]
+    fn test_incomplete_subscript() {
+        let err = from_str("a[0").unwrap_err();
+        assert_eq!("", err.to_string());
+    }
+
+    #[test]
+    fn test_invalid_postfix() {
+        let err = from_str("a!b").unwrap_err();
+        assert_eq!("", err.to_string());
+    }
 }


### PR DESCRIPTION
In version 0.15.0, the refactor to use winnow under the hood has made the error messages always blank.

As an example, this program
```rust
fn main() {
    for input in ["a..b", "a.", "a["] {
        let err = config::Config::builder()
            .set_override(input, "a")
            .unwrap_err();
        eprintln!("input = {input:5}, error =\n{err}");
    }
}
```
outputs 
```text
input = a..b , error =

input = a.   , error =

input = a[   , error =

```

The error messages are blank for two reasons
1. [`winnow::Parser::context`](https://docs.rs/winnow/latest/winnow/trait.Parser.html#method.context) isn't used to label the parser fragments
2. [`winnow::Parser::parse`](https://docs.rs/winnow/latest/winnow/trait.Parser.html#method.parse) isn't used at https://github.com/rust-cli/config-rs/blob/eec8d6d0cb7f65efa338d9b965788e887e28084f/src/path/parser.rs#L20 so the location in the input where the parsing failed is not shown.

With the changes in this PR, the program above would print
```text
input = a..b , error =
a..b
  ^
invalid identifier
expected ASCII alphanumeric, underscore, hyphen
input = a.   , error =
a.
  ^
invalid identifier
expected ASCII alphanumeric, underscore, hyphen
input = a[   , error =
a[
  ^
invalid subscript
expected integer
```

<hr>

One little thing that I couldn't get to work how I wanted was the cursor position in the case of an invalid 'postfix' character:
```text
a!b
  ^
invalid postfix
expected `[`, `.`
```
In this example I would really expect the `^` to line up with the `!`, but the `dispatch!` macro used will always consume the character matched. I couldn't find a better way to do it with `winnow`, but maybe someone else will know how.