### PR TITLE
feat: add case conversion strategies to include/exclude keys

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -34,9 +34,9 @@ pub struct Environment {
 
     /// Optional directive to translate collected keys into a form that matches what serializers
     /// that the configuration would expect. For example if you have the `kebab-case` attribute
-    /// for your serde config types, you may want to pass `Case::Kebab` here.
+    /// for your serde config types, you may want to pass `ConversionStrategy::All(Case::Kebab)` here.
     #[cfg(feature = "convert-case")]
-    convert_case: Option<Case>,
+    convert_case: Option<ConversionStrategy>,
 
     /// Optional character sequence that separates each env value into a vector. only works when `try_parsing` is set to true
     /// Once set, you cannot have type String on the same environment, unless you set `list_parse_keys`.
@@ -90,6 +90,15 @@ pub struct Environment {
     source: Option<Map<String, String>>,
 }
 
+/// Strategy to translate collected keys into a form that matches what serializers
+/// that the configuration would expect.
+#[cfg(feature = "convert-case")]
+#[derive(Clone, Debug)]
+enum ConversionStrategy {
+    /// Apply the conversion to all collected keys
+    All(Case),
+}
+
 impl Environment {
     /// Optional prefix that will limit access to the environment to only keys that
     /// begin with the defined prefix.
@@ -118,7 +127,7 @@ impl Environment {
 
     #[cfg(feature = "convert-case")]
     pub fn convert_case(mut self, tt: Case) -> Self {
-        self.convert_case = Some(tt);
+        self.convert_case = Some(ConversionStrategy::All(tt));
         self
     }
 
@@ -270,7 +279,7 @@ impl Source for Environment {
             }
 
             #[cfg(feature = "convert-case")]
-            if let Some(convert_case) = convert_case {
+            if let Some(ConversionStrategy::All(convert_case)) = convert_case {
                 key = key.to_case(*convert_case);
             }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -136,14 +136,28 @@ impl Environment {
     }
 
     #[cfg(feature = "convert-case")]
-    pub fn convert_case_exclude_keys(mut self, tt: Case, keys: Vec<String>) -> Self {
-        self.convert_case = Some(ConversionStrategy::Exclude(tt, keys));
+    pub fn convert_case_exclude_keys(
+        mut self,
+        tt: Case,
+        keys: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.convert_case = Some(ConversionStrategy::Exclude(
+            tt,
+            keys.into_iter().map(|k| k.into()).collect(),
+        ));
         self
     }
 
     #[cfg(feature = "convert-case")]
-    pub fn convert_case_for_keys(mut self, tt: Case, keys: Vec<String>) -> Self {
-        self.convert_case = Some(ConversionStrategy::Only(tt, keys));
+    pub fn convert_case_for_keys(
+        mut self,
+        tt: Case,
+        keys: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.convert_case = Some(ConversionStrategy::Only(
+            tt,
+            keys.into_iter().map(|k| k.into()).collect(),
+        ));
         self
     }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -99,6 +99,8 @@ enum ConversionStrategy {
     All(Case),
     /// Exclude the specified keys from conversion
     Exclude(Case, Vec<String>),
+    /// Only convert the specified keys
+    Only(Case, Vec<String>),
 }
 
 impl Environment {
@@ -136,6 +138,12 @@ impl Environment {
     #[cfg(feature = "convert-case")]
     pub fn convert_case_exclude_keys(mut self, tt: Case, keys: Vec<String>) -> Self {
         self.convert_case = Some(ConversionStrategy::Exclude(tt, keys));
+        self
+    }
+
+    #[cfg(feature = "convert-case")]
+    pub fn convert_case_for_keys(mut self, tt: Case, keys: Vec<String>) -> Self {
+        self.convert_case = Some(ConversionStrategy::Only(tt, keys));
         self
     }
 
@@ -292,6 +300,11 @@ impl Source for Environment {
                     ConversionStrategy::All(convert_case) => key = key.to_case(*convert_case),
                     ConversionStrategy::Exclude(convert_case, keys) => {
                         if !keys.contains(&key) {
+                            key = key.to_case(*convert_case);
+                        }
+                    }
+                    ConversionStrategy::Only(convert_case, keys) => {
+                        if keys.contains(&key) {
                             key = key.to_case(*convert_case);
                         }
                     }

--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -602,6 +602,33 @@ fn test_parse_kebab_case_with_exclude_keys() {
 }
 
 #[test]
+#[cfg(feature = "convert-case")]
+fn test_parse_kebab_case_for_keys() {
+    use config::Case;
+    #[derive(Deserialize, Debug)]
+    struct TestConfig {
+        value_a: String,
+        #[serde(rename = "value-b")]
+        value_b: String,
+    }
+
+    temp_env::with_vars(
+        vec![("VALUE_A", Some("value1")), ("VALUE_B", Some("value2"))],
+        || {
+            let environment = Environment::default()
+                .convert_case_for_keys(Case::Kebab, vec!["value_b".to_owned()]);
+
+            let config = Config::builder().add_source(environment).build().unwrap();
+
+            let config: TestConfig = config.try_deserialize().unwrap();
+
+            assert_eq!(config.value_a, "value1");
+            assert_eq!(config.value_b, "value2");
+        },
+    );
+}
+
+#[test]
 fn test_parse_string() {
     // using a struct in an enum here to make serde use `deserialize_any`
     #[derive(Deserialize, Debug)]

--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -588,8 +588,8 @@ fn test_parse_kebab_case_with_exclude_keys() {
     temp_env::with_vars(
         vec![("VALUE_A", Some("value1")), ("VALUE_B", Some("value2"))],
         || {
-            let environment = Environment::default()
-                .convert_case_exclude_keys(Case::Kebab, vec!["value_a".to_owned()]);
+            let environment =
+                Environment::default().convert_case_exclude_keys(Case::Kebab, ["value_a"]);
 
             let config = Config::builder().add_source(environment).build().unwrap();
 
@@ -615,8 +615,8 @@ fn test_parse_kebab_case_for_keys() {
     temp_env::with_vars(
         vec![("VALUE_A", Some("value1")), ("VALUE_B", Some("value2"))],
         || {
-            let environment = Environment::default()
-                .convert_case_for_keys(Case::Kebab, vec!["value_b".to_owned()]);
+            let environment =
+                Environment::default().convert_case_for_keys(Case::Kebab, ["value_b"]);
 
             let config = Config::builder().add_source(environment).build().unwrap();
 

--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -575,6 +575,33 @@ fn test_parse_nested_kebab() {
 }
 
 #[test]
+#[cfg(feature = "convert-case")]
+fn test_parse_kebab_case_with_exclude_keys() {
+    use config::Case;
+    #[derive(Deserialize, Debug)]
+    struct TestConfig {
+        value_a: String,
+        #[serde(rename = "value-b")]
+        value_b: String,
+    }
+
+    temp_env::with_vars(
+        vec![("VALUE_A", Some("value1")), ("VALUE_B", Some("value2"))],
+        || {
+            let environment = Environment::default()
+                .convert_case_exclude_keys(Case::Kebab, vec!["value_a".to_owned()]);
+
+            let config = Config::builder().add_source(environment).build().unwrap();
+
+            let config: TestConfig = config.try_deserialize().unwrap();
+
+            assert_eq!(config.value_a, "value1");
+            assert_eq!(config.value_b, "value2");
+        },
+    );
+}
+
+#[test]
 fn test_parse_string() {
     // using a struct in an enum here to make serde use `deserialize_any`
     #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This PR introduces two new strategies for case conversion, which allow users to either specify a list of keys that should be converted or exclude a list of keys from conversion. This solves issue #625 that it is currently not possible to exclude some keys from case conversion.