### PR TITLE
treat nil parents as empty tables if required

### DIFF
--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -150,12 +150,16 @@ impl Expression {
         let parent = self.get_mut_forcibly(root);
         match value.kind {
             ValueKind::Table(ref incoming_map) => {
+                // If the parent is nil, treat it as an empty table
+                if matches!(parent.kind, ValueKind::Nil) {
+                    *parent = Map::<String, Value>::new().into();
+                }
+
                 // Continue the deep merge
                 for (key, val) in incoming_map {
                     Self::root(key.clone()).set(parent, val.clone());
                 }
             }
-
             _ => {
                 *parent = value;
             }

--- a/src/path/mod.rs
+++ b/src/path/mod.rs
@@ -150,8 +150,9 @@ impl Expression {
         let parent = self.get_mut_forcibly(root);
         match value.kind {
             ValueKind::Table(ref incoming_map) => {
-                // If the parent is nil, treat it as an empty table
-                if matches!(parent.kind, ValueKind::Nil) {
+                // If the parent is not a table, overwrite it, treating it as a
+                // table
+                if !matches!(parent.kind, ValueKind::Table(_)) {
                     *parent = Map::<String, Value>::new().into();
                 }
 

--- a/tests/testsuite/merge.rs
+++ b/tests/testsuite/merge.rs
@@ -112,10 +112,17 @@ fn test_merge_empty_maps() {
         .unwrap();
     let res = cfg.try_deserialize::<Settings>();
     assert_data_eq!(
-        res.unwrap_err().to_string(),
-        str![
-            "invalid type: unit value, expected struct Profile for key `profile.missing_to_empty`"
-        ]
+        res.unwrap().to_debug(),
+        str![[r#"
+Settings {
+    profile: {
+        "missing_to_empty": Profile {
+            name: None,
+        },
+    },
+}
+
+"#]]
     );
 
     // * missing_to_non_empty: no key -> map with k/v
@@ -158,8 +165,17 @@ Settings {
         .unwrap();
     let res = cfg.try_deserialize::<Settings>();
     assert_data_eq!(
-        res.unwrap_err().to_string(),
-        str!["invalid type: unit value, expected struct Profile for key `profile.empty_to_empty`"]
+        res.unwrap().to_debug(),
+        str![[r#"
+Settings {
+    profile: {
+        "empty_to_empty": Profile {
+            name: None,
+        },
+    },
+}
+
+"#]]
     );
 
     // * empty_to_non_empty: empty map -> map with k/v
@@ -266,8 +282,17 @@ Settings {
         .unwrap();
     let res = cfg.try_deserialize::<Settings>();
     assert_data_eq!(
-        res.unwrap_err().to_string(),
-        str!["invalid type: unit value, expected struct Profile for key `profile.null_to_empty`"]
+        res.unwrap().to_debug(),
+        str![[r#"
+Settings {
+    profile: {
+        "null_to_empty": Profile {
+            name: None,
+        },
+    },
+}
+
+"#]]
     );
 
     // * null_to_non_empty: null -> map with k/v

--- a/tests/testsuite/merge.rs
+++ b/tests/testsuite/merge.rs
@@ -338,8 +338,17 @@ Settings {
         .unwrap();
     let res = cfg.try_deserialize::<Settings>();
     assert_data_eq!(
-        res.unwrap_err().to_string(),
-        str!["invalid type: integer `42`, expected struct Profile for key `profile.int_to_empty`"]
+        res.unwrap().to_debug(),
+        str![[r#"
+Settings {
+    profile: {
+        "int_to_empty": Profile {
+            name: None,
+        },
+    },
+}
+
+"#]]
     );
 
     // * int_to_non_empty: int -> map with k/v


### PR DESCRIPTION
Encountered this regression via nextest's test suite (https://github.com/nextest-rs/nextest/pull/2001). If a table is empty, it would be treated as a unit value. If attempted to be deserialized via a `Default` impl, this would lead to deserialization failing with an error like

```console
profile.default-miri: invalid type: unit value, expected struct CustomProfileImpl
```

A bisect appears to indicate that ec36bff45eb339077e23d47d2edabc0bcd03cf6c is responsible.

I've attempted to restore the old behavior of putting in an empty table, specifically this section:

https://github.com/rust-cli/config-rs/commit/ec36bff45eb339077e23d47d2edabc0bcd03cf6c#diff-c5423e2d2d6c87501239c0304c0f496742e00440defdd20368cf548ba42ab184L175-L178

I'm happy to make changes if there's a better approach.

I've also added some tests for a few situations around empty tables. In this case only the last one (`profile.baz`) regressed, but I've also added tests for a couple other cases.

Fixes #624