### PR TITLE
Add `try_deserialize` deserialization path error tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_path_to_error",
  "snapbox",
  "temp-env",
  "tokio",
@@ -1352,18 +1353,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1626,18 +1627,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1653,6 +1654,16 @@ dependencies = [
  "indexmap 2.2.2",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -1776,9 +1787,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ indexmap = { version = "2.2", features = ["serde"], optional = true }
 convert_case = { version = "0.6", optional = true }
 pathdiff = "0.2"
 winnow = "0.6.20"
+serde_path_to_error = "0.1"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/tests/testsuite/errors.rs
+++ b/tests/testsuite/errors.rs
@@ -316,3 +316,39 @@ fn test_error_root_not_table() {
         },
     }
 }
+
+#[test]
+#[cfg(feature = "json")]
+fn test_json_error_with_path() {
+    #[derive(Debug, Deserialize)]
+    struct InnerSettings {
+        #[allow(dead_code)]
+        value: u32,
+        #[allow(dead_code)]
+        value2: u32,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Settings {
+        #[allow(dead_code)]
+        inner: InnerSettings,
+    }
+
+    let c = Config::builder()
+        .add_source(File::from_str(
+            r#"
+{
+    "inner": { "value": 42 }
+}
+        "#,
+            FileFormat::Json,
+        ))
+        .build()
+        .unwrap();
+
+    let with_path = c.clone().try_deserialize::<Settings>();
+    assert_data_eq!(
+        with_path.unwrap_err().to_string(),
+        str!["missing field `value2`"]
+    );
+}

--- a/tests/testsuite/errors.rs
+++ b/tests/testsuite/errors.rs
@@ -341,7 +341,7 @@ fn test_json_error_with_path() {
     "inner": { "value": 42 }
 }
         "#,
-            FileFormat::Json,
+            FileFormat::Json5,
         ))
         .build()
         .unwrap();
@@ -349,6 +349,6 @@ fn test_json_error_with_path() {
     let with_path = c.clone().try_deserialize::<Settings>();
     assert_data_eq!(
         with_path.unwrap_err().to_string(),
-        str!["missing field `value2`"]
+        str!["failed reading field `inner`: missing field `value2`"]
     );
 }

--- a/tests/testsuite/log.rs
+++ b/tests/testsuite/log.rs
@@ -53,6 +53,6 @@ fn test_load_level_lowercase() {
     assert!(s.is_err());
     assert_data_eq!(
         s.unwrap_err().to_string(),
-        str!["enum Level does not have variant constructor error"]
+        str!["failed reading field `log`: enum Level does not have variant constructor error"]
     );
 }


### PR DESCRIPTION
Hi!
I'm using `config-rs`, but I'm having some difficulties finding where my JSON file lacks fields.
I have a nested configuration struct like the one below:
```rust
#[derive(Debug, Deserialize)]
struct InnerSettings {
    #[allow(dead_code)]
    value: u32,
    #[allow(dead_code)]
    value2: u32,
}

#[derive(Debug, Deserialize)]
struct Settings {
    #[allow(dead_code)]
    inner: InnerSettings,
}
```

NB: my use case involves more complex structures

So, if you try to deserialize a wrong JSON, the error will contains the JSON path:
```rust

let c = Config::builder()
    .add_source(File::from_str(
        r#"
{
"inner": { "value": 42 }
}
    "#,
        FileFormat::Json,
    ))
    .build()
    .unwrap();

let without_path = c.clone().try_deserialize::<Settings>();
assert_data_eq!(
    without_path.unwrap_err().to_string(),
    str!["inner: missing field `value2`"] // prepended with JSON path
);
```

This PR:
- adds [`serde_path_to_error`](https://crates.io/crates/serde_path_to_error)
- add a JSON path if not empty in front of the error.
- adds a test
- add method documentation

