### PR TITLE
Handle non Unicode env keys/values

### DIFF
--- a/tests/testsuite/env.rs
+++ b/tests/testsuite/env.rs
@@ -721,3 +721,79 @@ fn test_parse_uint_default() {
     let config: TestUint = config.try_deserialize().unwrap();
     assert_eq!(config.int_val, 42);
 }
+
+#[cfg(any(unix, windows))]
+#[cfg(test)]
+mod unicode_tests {
+    use std::ffi::OsString;
+
+    use super::*;
+
+    fn make_invalid_unicode_os_string() -> OsString {
+        let string = {
+            #[cfg(unix)]
+            {
+                use std::os::unix::ffi::OsStringExt;
+
+                OsString::from_vec(vec![0xff])
+            }
+            #[cfg(windows)]
+            {
+                use std::os::windows::ffi::OsStringExt;
+
+                OsString::from_wide(&[0xd800]) // unpaired high surrogate
+            }
+        };
+
+        assert!(string.to_str().is_none());
+
+        string
+    }
+
+    #[test]
+    #[should_panic(expected = r#"`Result::unwrap()` on an `Err` value: "\xFF""#)]
+    fn test_invalid_unicode_key_ignored() {
+        temp_env::with_vars(
+            vec![
+                (make_invalid_unicode_os_string(), Some("abc")),
+                ("A_B_C".into(), Some("abc")),
+            ],
+            || {
+                let vars = Environment::default().collect().unwrap();
+
+                assert!(vars.contains_key("a_b_c"));
+            },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = r#"`Result::unwrap()` on an `Err` value: "\xFF""#)]
+    fn test_invalid_unicode_value_filtered() {
+        temp_env::with_vars(
+            vec![
+                ("invalid_value1", Some(make_invalid_unicode_os_string())),
+                ("valid_value2", Some("valid".into())),
+            ],
+            || {
+                let vars = Environment::with_prefix("valid")
+                    .keep_prefix(true)
+                    .collect()
+                    .unwrap();
+
+                assert!(!vars.contains_key("invalid_value1"));
+                assert!(vars.contains_key("valid_value2"));
+            },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = r#"`Result::unwrap()` on an `Err` value: "\xFF""#)]
+    fn test_invalid_unicode_value_not_filtered() {
+        temp_env::with_vars(
+            vec![("invalid_value1", Some(make_invalid_unicode_os_string()))],
+            || {
+                Environment::default().collect().unwrap();
+            },
+        );
+    }
+}


### PR DESCRIPTION
(disregard the code / commit message - I'll clean up & add tests once we agree on the implementation :smile:  )

I hit the same issue as described in the linked ticket - with key `PWD` having a non-UTF-8 value ("invalid" from now on).

Technically, keys can be invalid too in Linux. The naive implementation I provided here filters out all invalid keys & values. Keys in config-rs are `String`s so it always makes sense to filter invalid ones, as they won't be used by this library AFAIU.
As for values - I'm unsure if plainly ignoring invalid values is okay. If the value is set in a key that would have been used by the current config consumer, then ignoring it (as if the user did not provide a value through env) is not okay.
Ideally - the logic would be:
1. Valid key & value - continue
2. Invalid key - drop
3. Invalid value - drop if key is not consumed, otherwise panic.

Let me know what you think :) I can try looking into point 3.

Resolves: https://github.com/rust-cli/config-rs/issues/579
