### PR TITLE
feat: Add support for float and boolean hash keys

### DIFF
--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -51,6 +51,7 @@ fn from_yaml_value(
                     yaml::Yaml::String(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
                     yaml::Yaml::Integer(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
                     yaml::Yaml::Boolean(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
+                    yaml::Yaml::Real(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
                     other => Err(Box::new(UnsupportedHashKeyError(format!("{other:?}"))))?,
                 };
             }

--- a/tests/testsuite/file_yaml.rs
+++ b/tests/testsuite/file_yaml.rs
@@ -382,3 +382,22 @@ inner_bool:
     assert_eq!(config.inner_bool.get(&true).unwrap(), "bool true");
     assert_eq!(config.inner_bool.get(&false).unwrap(), "bool false");
 }
+
+#[test]
+fn test_yaml_parsing_float_hash() {
+    let result = Config::builder()
+        .add_source(File::from_str(
+            r#"
+inner_float:
+    0.1: "float 0.1"
+    0.2: "float 0.2"
+"#,
+            FileFormat::Yaml,
+        ))
+        .build();
+    assert!(result.is_err());
+    assert_data_eq!(
+        result.unwrap_err().to_string(),
+        str!["Cannot parse Real(\"0.1\") because it is an unsupported hash key type"]
+    );
+}

--- a/tests/testsuite/file_yaml.rs
+++ b/tests/testsuite/file_yaml.rs
@@ -385,7 +385,12 @@ inner_bool:
 
 #[test]
 fn test_yaml_parsing_float_hash() {
-    let result = Config::builder()
+    #[derive(Debug, Deserialize)]
+    struct TestStruct {
+        inner_float: HashMap<String, String>,
+    }
+
+    let config = Config::builder()
         .add_source(File::from_str(
             r#"
 inner_float:
@@ -394,10 +399,10 @@ inner_float:
 "#,
             FileFormat::Yaml,
         ))
-        .build();
-    assert!(result.is_err());
-    assert_data_eq!(
-        result.unwrap_err().to_string(),
-        str!["Cannot parse Real(\"0.1\") because it is an unsupported hash key type"]
-    );
+        .build()
+        .unwrap()
+        .try_deserialize::<TestStruct>()
+        .unwrap();
+    assert_eq!(config.inner_float.get("0.1").unwrap(), "float 0.1");
+    assert_eq!(config.inner_float.get("0.2").unwrap(), "float 0.2");
 }


### PR DESCRIPTION
The `unreachable!` code at https://github.com/rust-cli/config-rs/blob/main/src/file/format/yaml.rs#L53 is reachable, and this PR fixes it for two simple types: reals and booleans.

Prior to this change you'd get this error trying to parse the following:
```
thread '...' panicked at .../config-0.15.9/src/file/format/yaml.rs:53:26:
internal error: entered unreachable code
```

The problematic case for me turned out to be float keys:
```yaml
inner_float:
    0.1: "float 0.1"
    0.2: "float 0.2"
```

The change in this PR follows the same pattern as already exists for Strings and Integers - just parse them as strings and leave it up to the user to work out what to do with that.

Personally I only need the Real support, so happy to remove the Boolean case if that's at all contentious.

I decided not to look into whether you can craft a hash with the other Yaml types (below) because it's such an odd use case it didn't seam realistic! That said, https://github.com/rust-cli/config-rs/issues/547 suggests that just treating Hash as string would have avoided that users' problem. However, converting from these types back into the exact string format they were parsed in would be difficult, so it's not clear what the right implementation would be. So getting the simpler case (reals, booleans) done feels like the right sized change to make.
```
    Array(Array),
    Hash(Hash),
    Alias(usize),
    Null,
    BadValue,
 ```

Let me know what you think! And thanks for maintaining this useful crate :)