### PR TITLE
Allow bool hash and dont panic

### DIFF
--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -50,6 +50,7 @@ fn from_yaml_value(
                 match key {
                     yaml::Yaml::String(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
                     yaml::Yaml::Integer(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
+                    yaml::Yaml::Boolean(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
                     other => Err(Box::new(UnsupportedHashKeyError(format!("{other:?}"))))?,
                 };
             }

--- a/src/file/format/yaml.rs
+++ b/src/file/format/yaml.rs
@@ -50,7 +50,7 @@ fn from_yaml_value(
                 match key {
                     yaml::Yaml::String(k) => m.insert(k.to_owned(), from_yaml_value(uri, value)?),
                     yaml::Yaml::Integer(k) => m.insert(k.to_string(), from_yaml_value(uri, value)?),
-                    _ => unreachable!(),
+                    other => Err(Box::new(UnsupportedHashKeyError(format!("{other:?}"))))?,
                 };
             }
             Ok(Value::new(uri, ValueKind::Table(m)))
@@ -101,5 +101,24 @@ impl fmt::Display for FloatParsingError {
 impl Error for FloatParsingError {
     fn description(&self) -> &str {
         "Floating point number parsing failed"
+    }
+}
+
+#[derive(Debug, Clone)]
+struct UnsupportedHashKeyError(String);
+
+impl fmt::Display for UnsupportedHashKeyError {
+    fn fmt(&self, format: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            format,
+            "Cannot parse {} because it is an unsupported hash key type",
+            self.0
+        )
+    }
+}
+
+impl Error for UnsupportedHashKeyError {
+    fn description(&self) -> &str {
+        "Unsupported yaml hash key found"
     }
 }

--- a/tests/testsuite/file_yaml.rs
+++ b/tests/testsuite/file_yaml.rs
@@ -340,8 +340,9 @@ fn yaml() {
 }
 
 #[test]
-#[should_panic]
-fn test_yaml_parsing_unsupported_hash() {
+/// We only support certain types as keys to a yaml hash, this test ensures
+/// we communicate that to the user effectively.
+fn test_yaml_parsing_unsupported_hash_has_useful_error_message() {
     let result = Config::builder()
         .add_source(File::from_str(
             r#"
@@ -352,4 +353,8 @@ inner_vec:
         ))
         .build();
     assert!(result.is_err());
+    assert_data_eq!(
+        result.unwrap_err().to_string(),
+        str!["Cannot parse Array([Integer(1), Integer(2)]) because it is an unsupported hash key type"]
+    );
 }

--- a/tests/testsuite/file_yaml.rs
+++ b/tests/testsuite/file_yaml.rs
@@ -358,3 +358,22 @@ inner_vec:
         str!["Cannot parse Array([Integer(1), Integer(2)]) because it is an unsupported hash key type"]
     );
 }
+
+#[test]
+fn test_yaml_parsing_bool_hash_fails() {
+    let result = Config::builder()
+        .add_source(File::from_str(
+            r#"
+inner_bool:
+    true: "bool true"
+    false: "bool false"
+"#,
+            FileFormat::Yaml,
+        ))
+        .build();
+    assert!(result.is_err());
+    assert_data_eq!(
+        result.unwrap_err().to_string(),
+        str!["Cannot parse Boolean(true) because it is an unsupported hash key type"]
+    );
+}

--- a/tests/testsuite/file_yaml.rs
+++ b/tests/testsuite/file_yaml.rs
@@ -360,8 +360,13 @@ inner_vec:
 }
 
 #[test]
-fn test_yaml_parsing_bool_hash_fails() {
-    let result = Config::builder()
+fn test_yaml_parsing_bool_hash() {
+    #[derive(Debug, Deserialize)]
+    struct TestStruct {
+        inner_bool: HashMap<bool, String>,
+    }
+
+    let config = Config::builder()
         .add_source(File::from_str(
             r#"
 inner_bool:
@@ -370,10 +375,10 @@ inner_bool:
 "#,
             FileFormat::Yaml,
         ))
-        .build();
-    assert!(result.is_err());
-    assert_data_eq!(
-        result.unwrap_err().to_string(),
-        str!["Cannot parse Boolean(true) because it is an unsupported hash key type"]
-    );
+        .build()
+        .unwrap()
+        .try_deserialize::<TestStruct>()
+        .unwrap();
+    assert_eq!(config.inner_bool.get(&true).unwrap(), "bool true");
+    assert_eq!(config.inner_bool.get(&false).unwrap(), "bool false");
 }

--- a/tests/testsuite/file_yaml.rs
+++ b/tests/testsuite/file_yaml.rs
@@ -338,3 +338,18 @@ fn yaml() {
     let date: DateTime<Utc> = s.get("yaml_datetime").unwrap();
     assert_eq!(date, Utc.with_ymd_and_hms(2017, 6, 12, 10, 58, 30).unwrap());
 }
+
+#[test]
+#[should_panic]
+fn test_yaml_parsing_unsupported_hash() {
+    let result = Config::builder()
+        .add_source(File::from_str(
+            r#"
+inner_vec:
+    [1, 2]: "unsupported"
+"#,
+            FileFormat::Yaml,
+        ))
+        .build();
+    assert!(result.is_err());
+}


### PR DESCRIPTION
See discussion in https://github.com/rust-cli/config-rs/pull/650/

Pulled out 2 features from that MR:
- Useful error message on unsupported yaml hash keys
- Support for boolean hash keys