### PR TITLE
fix: Add slash character for path.parse to support nested slash environment variables

### DIFF
--- a/src/path/parser.rs
+++ b/src/path/parser.rs
@@ -52,7 +52,7 @@ fn postfix(i: &mut &str) -> ModalResult<Postfix> {
 }
 
 fn ident(i: &mut &str) -> ModalResult<String> {
-    take_while(1.., ('a'..='z', 'A'..='Z', '0'..='9', '_', '-'))
+    take_while(1.., ('a'..='z', 'A'..='Z', '0'..='9', '_', '-', '/'))
         .map(ToOwned::to_owned)
         .context(StrContext::Label("identifier"))
         .context(StrContext::Expected(StrContextValue::Description(
@@ -143,6 +143,22 @@ Expression {
         ),
         Key(
             "ijkl",
+        ),
+    ],
+}
+
+"#]]
+        );
+
+        let parsed: Expression = from_str("nested/slash.v").unwrap();
+        assert_data_eq!(
+            parsed.to_debug(),
+            str![[r#"
+Expression {
+    root: "nested/slash",
+    postfix: [
+        Key(
+            "v",
         ),
     ],
 }


### PR DESCRIPTION
This library cannot parse successfully if the environment variables contain a slash and have nested values.
For example:

```rust
use config::Config;
use serde::Deserialize;

#[derive(Debug, Deserialize, PartialEq)]
struct ChildValue {
    v: u8,
}

#[derive(Debug, Deserialize, PartialEq)]
struct SlashNested {
    #[serde(rename = "slash/nested")]
    nested: ChildValue,
}

fn main() {
    let env = config::Environment::with_prefix("APP").separator("_");
    std::env::set_var("APP_slash/nested_v", "42");

    let config = Config::builder().add_source(env).build().unwrap();
    println!("{:?}", config.cache.to_string());

    let app: SlashNested = config.try_deserialize().unwrap();

    assert_eq!(
        app,
        SlashNested {
            nested: ChildValue { v: 42 }
        }
    );

    std::env::remove_var("APP_slash/nested_v");
}
```

Expected behavior:
- parse successfully with log `"{ slash/nested => { v => 42,  },  }"`

Current behavior:

- parse failed(panicked) with log `"{ slash/nested.v => 42,  }"`