### PR TITLE
docs: List default value for `Environment::prefix_separator`

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -28,6 +28,7 @@ pub struct Environment {
     prefix: Option<String>,
 
     /// Optional character sequence that separates the prefix from the rest of the key.
+    ///
     /// Defaults to [`separator`](Environment::separator()) if that is set, otherwise `_`.
     prefix_separator: Option<String>,
 
@@ -128,6 +129,7 @@ impl Environment {
     }
 
     /// Optional character sequence that separates the prefix from the rest of the key.
+    ///
     /// Defaults to [`separator`](Environment::separator()) if that is set, otherwise `_`.
     pub fn prefix_separator(mut self, s: &str) -> Self {
         self.prefix_separator = Some(s.into());

--- a/src/env.rs
+++ b/src/env.rs
@@ -20,13 +20,15 @@ pub struct Environment {
     /// Optional prefix that will limit access to the environment to only keys that
     /// begin with the defined prefix.
     ///
-    /// A prefix with a separator of `_` is tested to be present on each key before its considered
-    /// to be part of the source environment.
+    /// The prefix is tested to be present on each key before it's considered to be part of the
+    /// source environment. The separator character can be set through
+    /// [`prefix_separator`](Environment::prefix_separator()).
     ///
     /// For example, the key `CONFIG_DEBUG` would become `DEBUG` with a prefix of `config`.
     prefix: Option<String>,
 
-    /// Optional character sequence that separates the prefix from the rest of the key
+    /// Optional character sequence that separates the prefix from the rest of the key.
+    /// Defaults to [`separator`](Environment::separator()) if that is set, otherwise `_`.
     prefix_separator: Option<String>,
 
     /// Optional character sequence that separates each key segment in an environment key pattern.
@@ -96,8 +98,9 @@ impl Environment {
     /// Optional prefix that will limit access to the environment to only keys that
     /// begin with the defined prefix.
     ///
-    /// A prefix with a separator of `_` is tested to be present on each key before its considered
-    /// to be part of the source environment.
+    /// The prefix is tested to be present on each key before it's considered to be part of the
+    /// source environment. The separator character can be set through
+    /// [`prefix_separator`](Environment::prefix_separator()).
     ///
     /// For example, the key `CONFIG_DEBUG` would become `DEBUG` with a prefix of `config`.
     pub fn with_prefix(s: &str) -> Self {
@@ -124,7 +127,8 @@ impl Environment {
         self
     }
 
-    /// Optional character sequence that separates the prefix from the rest of the key
+    /// Optional character sequence that separates the prefix from the rest of the key.
+    /// Defaults to [`separator`](Environment::separator()) if that is set, otherwise `_`.
     pub fn prefix_separator(mut self, s: &str) -> Self {
         self.prefix_separator = Some(s.into());
         self


### PR DESCRIPTION
List the default value for the `Environment::prefix_separator` property.

The default for `prefix_separator` is determined by:

https://github.com/rust-cli/config-rs/blob/ad773ab9febb8e9064bfbbc75795506f224de68b/src/env.rs#L230-L234