### PR TITLE
perf: Update TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
  "tokio",
  "toml",
  "warp",
- "winnow 0.7.0",
+ "winnow",
  "yaml-rust2",
 ]
 
@@ -1651,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -1962,38 +1962,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "f271e09bde39ab52250160a67e88577e0559ad77e9085de6e9051a2c4353f8f8"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.7"
+name = "toml_parser"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "b5c1c469eda89749d2230d8156a5969a69ffe0d6d01200581cdc6110674d293e"
 dependencies = [
- "indexmap 2.2.2",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.6.26",
+ "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b679217f2848de74cabd3e8fc5e6d66f40b7da40f8e1954d92054d9010690fd5"
 
 [[package]]
 name = "tower-service"
@@ -2494,18 +2498,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
  "float-cmp",
  "futures",
  "glob",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "json5",
  "log",
  "notify",
@@ -592,7 +592,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -868,12 +868,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -1475,7 +1475,7 @@ checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.5",
  "bitflags 2.4.1",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "serde",
  "serde_derive",
 ]
@@ -1643,7 +1643,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -1966,7 +1966,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f271e09bde39ab52250160a67e88577e0559ad77e9085de6e9051a2c4353f8f8"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ yaml-rust2 = { version = "0.10", optional = true }
 rust-ini = { version = "0.21", optional = true }
 ron = { version = "0.8", optional = true }
 json5_rs = { version = "0.4", optional = true, package = "json5" }
-indexmap = { version = "2.2", features = ["serde"], optional = true }
+indexmap = { version = "2.10.0", features = ["serde"], optional = true }
 convert_case = { version = "0.6", optional = true }
 pathdiff = "0.2"
 winnow = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ toml = ["dep:toml"]
 serde = "1.0"
 
 async-trait = { version = "0.1", optional = true }
-toml = { version = "0.8", optional = true, default-features = false, features = ["parse"] }
+toml = { version = "0.9", optional = true, default-features = false, features = ["parse", "serde"] }
 serde_json = { version = "1.0", optional = true }
 yaml-rust2 = { version = "0.10", optional = true }
 rust-ini = { version = "0.21", optional = true }

--- a/src/file/format/toml.rs
+++ b/src/file/format/toml.rs
@@ -8,33 +8,33 @@ pub(crate) fn parse(
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a TOML value from the provided text
-    let table = from_toml_table(uri, &toml::from_str(text)?);
+    let table = from_toml_table(uri, toml::from_str(text)?);
     Ok(table)
 }
 
-fn from_toml_table(uri: Option<&String>, table: &toml::Table) -> Map<String, Value> {
+fn from_toml_table(uri: Option<&String>, table: toml::Table) -> Map<String, Value> {
     let mut m = Map::new();
 
     for (key, value) in table {
-        m.insert(key.clone(), from_toml_value(uri, value));
+        m.insert(key, from_toml_value(uri, value));
     }
 
     m
 }
 
-fn from_toml_value(uri: Option<&String>, value: &toml::Value) -> Value {
-    match *value {
-        toml::Value::String(ref value) => Value::new(uri, value.clone()),
+fn from_toml_value(uri: Option<&String>, value: toml::Value) -> Value {
+    match value {
+        toml::Value::String(value) => Value::new(uri, value),
         toml::Value::Float(value) => Value::new(uri, value),
         toml::Value::Integer(value) => Value::new(uri, value),
         toml::Value::Boolean(value) => Value::new(uri, value),
 
-        toml::Value::Table(ref table) => {
+        toml::Value::Table(table) => {
             let m = from_toml_table(uri, table);
             Value::new(uri, m)
         }
 
-        toml::Value::Array(ref array) => {
+        toml::Value::Array(array) => {
             let mut l = Vec::new();
 
             for value in array {
@@ -44,6 +44,6 @@ fn from_toml_value(uri: Option<&String>, value: &toml::Value) -> Value {
             Value::new(uri, l)
         }
 
-        toml::Value::Datetime(ref datetime) => Value::new(uri, datetime.to_string()),
+        toml::Value::Datetime(datetime) => Value::new(uri, datetime.to_string()),
     }
 }

--- a/src/file/format/toml.rs
+++ b/src/file/format/toml.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 
-use crate::format;
 use crate::map::Map;
 use crate::value::Value;
 
@@ -9,8 +8,18 @@ pub(crate) fn parse(
     text: &str,
 ) -> Result<Map<String, Value>, Box<dyn Error + Send + Sync>> {
     // Parse a TOML value from the provided text
-    let value = from_toml_value(uri, &toml::from_str(text)?);
-    format::extract_root_table(uri, value)
+    let table = from_toml_table(uri, &toml::from_str(text)?);
+    Ok(table)
+}
+
+fn from_toml_table(uri: Option<&String>, table: &toml::Table) -> Map<String, Value> {
+    let mut m = Map::new();
+
+    for (key, value) in table {
+        m.insert(key.clone(), from_toml_value(uri, value));
+    }
+
+    m
 }
 
 fn from_toml_value(uri: Option<&String>, value: &toml::Value) -> Value {
@@ -21,12 +30,7 @@ fn from_toml_value(uri: Option<&String>, value: &toml::Value) -> Value {
         toml::Value::Boolean(value) => Value::new(uri, value),
 
         toml::Value::Table(ref table) => {
-            let mut m = Map::new();
-
-            for (key, value) in table {
-                m.insert(key.clone(), from_toml_value(uri, value));
-            }
-
+            let m = from_toml_table(uri, table);
             Value::new(uri, m)
         }
 

--- a/tests/testsuite/file_toml.rs
+++ b/tests/testsuite/file_toml.rs
@@ -161,9 +161,8 @@ error = tru
 TOML parse error at line 3, column 9
   |
 3 | error = tru
-  |         ^
-invalid string
-expected `"`, `'`
+  |         ^^^
+invalid boolean, expected `true`
 
 "#]]
     );


### PR DESCRIPTION
For more context on the performance improvements, see https://epage.github.io/blog/2025/07/toml-09/

I held off on switching to `DeTable` (avoiding serde overhead) because `toml::de::DeInteger` doesn't expose enough of an API