### PR TITLE
chore: Remove `add_dummy_extension()` helper

### DIFF
--- a/src/file/source/file.rs
+++ b/src/file/source/file.rs
@@ -59,9 +59,13 @@ impl FileSourceFile {
                 )))
             };
         }
-        // Adding a dummy extension will make sure we will not override secondary extensions, i.e. "file.local"
-        // This will make the following set_extension function calls to append the extension.
-        let mut filename = add_dummy_extension(filename);
+
+        let mut filename = filename;
+        // Preserve any extension-like text within the provided file stem by appending a fake extension
+        // which will be replaced by `set_extension()` calls (e.g.  `file.local.placeholder` => `file.local.json`)
+        if filename.extension().is_some() {
+            filename.as_mut_os_string().push(".placeholder");
+        }
 
         match format_hint {
             Some(format) => {
@@ -133,19 +137,4 @@ where
             format,
         })
     }
-}
-
-fn add_dummy_extension(mut filename: PathBuf) -> PathBuf {
-    match filename.extension() {
-        Some(extension) => {
-            let mut ext = extension.to_os_string();
-            ext.push(".");
-            ext.push("dummy");
-            filename.set_extension(ext);
-        }
-        None => {
-            filename.set_extension("dummy");
-        }
-    }
-    filename
 }


### PR DESCRIPTION
The helper method is redundant (_introduced as a [bug fix in Mar 2022](https://github.com/rust-cli/config-rs/pull/306)_), there is a much simpler approach to append the extension.

- [`as_mut_os_string()`](https://doc.rust-lang.org/std/path/struct.Path.html#method.as_mut_os_str) has been available since Rust `1.70.0`, matching the MSRV of this crate since the introduction of [`OnceLock`](https://doc.rust-lang.org/std/sync/struct.OnceLock.html) [in Oct 2024](https://github.com/rust-cli/config-rs/pull/515) (_`0.14.1` release_).
- Additionally revised the comment and included a conditional statement to better communicate the intent for why this placeholder is necessary.