### PR TITLE
feat: Improve errors from try_deserialize

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -230,7 +230,7 @@ impl fmt::Display for ConfigError {
             ConfigError::Foreign(ref cause) => write!(f, "{cause}"),
 
             ConfigError::NotFound(ref key) => {
-                write!(f, "configuration property {key:?} not found")
+                write!(f, "missing configuration field {key:?}")
             }
 
             ConfigError::Type {

--- a/src/error.rs
+++ b/src/error.rs
@@ -289,6 +289,10 @@ impl de::Error for ConfigError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Self::Message(msg.to_string())
     }
+
+    fn missing_field(field: &'static str) -> Self {
+        Self::NotFound(field.into())
+    }
 }
 
 impl ser::Error for ConfigError {

--- a/tests/testsuite/errors.rs
+++ b/tests/testsuite/errors.rs
@@ -158,7 +158,7 @@ fn test_get_missing_field() {
     let res = c.get::<InnerSettings>("inner");
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str!["missing field `value2` for key `inner`"]
+        str![[r#"missing configuration field "value2" for key `inner`"#]]
     );
 }
 
@@ -184,7 +184,7 @@ fn test_get_missing_field_file() {
     let res = c.get::<InnerSettings>("inner");
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str!["missing field `value2` for key `inner`"]
+        str![[r#"missing configuration field "value2" for key `inner`"#]]
     );
 }
 
@@ -436,7 +436,7 @@ fn test_deserialize_missing_field() {
     let res = c.try_deserialize::<Settings>();
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str!["missing field `value2` for key `inner`"]
+        str![[r#"missing configuration field "inner.value2""#]]
     );
 }
 
@@ -468,6 +468,6 @@ fn test_deserialize_missing_field_file() {
     let res = c.try_deserialize::<Settings>();
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str!["missing field `value2` for key `inner`"]
+        str![[r#"missing configuration field "inner.value2""#]]
     );
 }

--- a/tests/testsuite/errors.rs
+++ b/tests/testsuite/errors.rs
@@ -22,7 +22,7 @@ fn test_path_index_bounds() {
     assert!(res.is_err());
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str![[r#"configuration property "arr[2]" not found"#]]
+        str![[r#"missing configuration field "arr[2]""#]]
     );
 }
 
@@ -45,7 +45,7 @@ fn test_path_index_negative_bounds() {
     assert!(res.is_err());
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str![[r#"configuration property "arr[-1]" not found"#]]
+        str![[r#"missing configuration field "arr[-1]""#]]
     );
 }
 

--- a/tests/testsuite/file_corn.rs
+++ b/tests/testsuite/file_corn.rs
@@ -185,7 +185,7 @@ fn test_override_uppercase_value_for_struct() {
             );
         }
         Err(e) => {
-            if e.to_string().contains("missing field `FOO`") {
+            if matches!(e, config::ConfigError::NotFound(_)) {
                 assert_eq!(
                     lower_settings.foo,
                     "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE".to_owned()

--- a/tests/testsuite/file_ini.rs
+++ b/tests/testsuite/file_ini.rs
@@ -128,7 +128,7 @@ rating = 4.5
             );
         }
         Err(e) => {
-            if e.to_string().contains("missing field `FOO`") {
+            if matches!(e, config::ConfigError::NotFound(_)) {
                 assert_eq!(
                     lower_settings.foo,
                     "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE".to_owned()

--- a/tests/testsuite/file_json.rs
+++ b/tests/testsuite/file_json.rs
@@ -178,7 +178,7 @@ fn test_override_uppercase_value_for_struct() {
             );
         }
         Err(e) => {
-            if e.to_string().contains("missing field `FOO`") {
+            if matches!(e, config::ConfigError::NotFound(_)) {
                 println!("triggered error {e:?}");
                 assert_eq!(
                     lower_settings.foo,

--- a/tests/testsuite/file_json5.rs
+++ b/tests/testsuite/file_json5.rs
@@ -187,7 +187,7 @@ fn test_override_uppercase_value_for_struct() {
             );
         }
         Err(e) => {
-            if e.to_string().contains("missing field `FOO`") {
+            if matches!(e, config::ConfigError::NotFound(_)) {
                 assert_eq!(
                     lower_settings.foo,
                     "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE".to_owned()

--- a/tests/testsuite/file_ron.rs
+++ b/tests/testsuite/file_ron.rs
@@ -179,7 +179,7 @@ fn test_override_uppercase_value_for_struct() {
             );
         }
         Err(e) => {
-            if e.to_string().contains("missing field `FOO`") {
+            if matches!(e, config::ConfigError::NotFound(_)) {
                 assert_eq!(
                     lower_settings.foo,
                     "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE".to_owned()

--- a/tests/testsuite/file_toml.rs
+++ b/tests/testsuite/file_toml.rs
@@ -266,7 +266,7 @@ down = 1
             );
         }
         Err(e) => {
-            if e.to_string().contains("missing field `FOO`") {
+            if matches!(e, config::ConfigError::NotFound(_)) {
                 assert_eq!(
                     lower_settings.foo,
                     "I HAVE BEEN OVERRIDDEN_WITH_UPPER_CASE".to_owned()

--- a/tests/testsuite/file_yaml.rs
+++ b/tests/testsuite/file_yaml.rs
@@ -210,7 +210,7 @@ bar: I am bar
             );
         }
         Err(e) => {
-            if e.to_string().contains("missing field `FOO`") {
+            if matches!(e, config::ConfigError::NotFound(_)) {
                 println!("triggered error {e:?}");
                 assert_eq!(
                     lower_settings.foo,

--- a/tests/testsuite/get.rs
+++ b/tests/testsuite/get.rs
@@ -18,7 +18,7 @@ fn test_not_found() {
     assert!(res.is_err());
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str![[r#"configuration property "not_found" not found"#]]
+        str![[r#"missing configuration field "not_found""#]]
     );
 }
 


### PR DESCRIPTION
Enables user code to handle missing and invalid fields after calling try_deserialize instead of having to match and search in the string returned in `ConfigError::Message`.

Personally I deem the `String::leak` call safe for my usage, as I would expect to terminate my program on configuration errors anyhow, however we could certainly also change the `expected` field to be a `Cow<str>` or similar to handle both `&'static str` and `String` elegantly.

Part of #532