### PR TITLE
Update json5 crate dependency from 0.4.1 to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,13 +832,12 @@ dependencies = [
 
 [[package]]
 name = "json5"
-version = "0.4.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
 dependencies = [
- "pest",
- "pest_derive",
  "serde",
+ "ucd-trie",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ serde_json = { version = "1.0.149", optional = true }
 yaml-rust2 = { version = "0.11.0", optional = true }
 rust-ini = { version = "0.21.3", optional = true }
 ron = { version = "0.12.0", optional = true }
-json5 = { version = "0.4.1", optional = true }
+json5 = { version = "1.3.1", optional = true }
 corn = { version = "0.10.1", optional = true, package = "libcorn" }
 indexmap = { version = "2.13.0", features = ["serde"], optional = true }
 convert_case = { version = "0.6.0", optional = true }

--- a/tests/testsuite/file_json5.rs
+++ b/tests/testsuite/file_json5.rs
@@ -115,14 +115,7 @@ fn test_error_parse() {
     assert!(res.is_err());
     assert_data_eq!(
         res.unwrap_err().to_string(),
-        str![[r#"
- --> 3:7
-  |
-3 |   ok: true
-  |       ^---
-  |
-  = expected null
-"#]]
+        str!["expected comma at line 4 column 3 at line 2 column 1"]
     );
 }
 


### PR DESCRIPTION
This updates the JSON5 dependency from v0.4.1 (2021-09-21) to v1.3.1 (2026-02-27).

If you look at the diff of [0.4.1...1.3.1](https://github.com/callum-oakley/json5-rs/compare/0.4.1...1.3.1) you can see v1.0.0 was a clean rewrite which switched licenses (ISC to MIT) and switched from a PEST.rs generated backend to a hand-written one.

This results in a smaller download (net -1.7MB when dependencies included) and a slightly faster build (1-3% when building config-rs with default features on my M5 Pro Macbook).

According to the author, performance is ~20x better:
> `google/serde_json5` was a fork of the Pest version of `serde_json5`
> 
> <img width="652" height="266" alt="serde_json5 benchmarks" src="https://github.com/user-attachments/assets/5906e982-4d61-42e9-b844-308f97364ddb" />